### PR TITLE
Add PTRAC card and keywords

### DIFF
--- a/syntax/mcnp.vim
+++ b/syntax/mcnp.vim
@@ -107,6 +107,27 @@ syn region imcnpType    start=/file\s*=\s*/   end=/\s/ end=/$/
 syn region imcnpComment start=/encode\s*=\s*/ end=/\s/ end=/$/
 syn region imcnpComment start=/decode\s*=\s*/ end=/\s/ end=/$/
 
+" PTRAC card
+syn keyword imcnpKeyword    ptrac
+" PTRAC output control
+syn region imcnpType    start=/buffer\s*=\s*/    end=/\s/ end=/$/
+syn region imcnpType    start=/file\s*=\s*/      end=/\s/ end=/$/
+syn region imcnpType    start=/flushnps\s*=\s*/  end=/\s/ end=/$/
+syn region imcnpType    start=/max\s*=\s*/       end=/\s/ end=/$/
+syn region imcnpType    start=/meph\s*=\s*/      end=/\s/ end=/$/
+syn region imcnpType    start=/write\s*=\s*/     end=/\s/ end=/$/
+syn region imcnpType    start=/coinc\s*=\s*/     end=/\s/ end=/$/
+" PTRAC event filter
+syn region imcnpKeyword start=/event\s*=\s*/     end=/\s/ end=/$/
+syn region imcnpKeyword start=/filter\s*=\s*/    end=/\s/ end=/$/
+syn region imcnpKeyword start=/type\s*=\s*/      end=/\s/ end=/$/
+" PTRAC history filter
+syn region imcnpComment start=/nps\s*=\s*/       end=/\s/ end=/$/
+syn region imcnpComment start=/cell\s*=\s*/      end=/\s/ end=/$/
+syn region imcnpComment start=/surface\s*=\s*/   end=/\s/ end=/$/
+syn region imcnpComment start=/tally\s*=\s*/     end=/\s/ end=/$/
+syn region imcnpComment start=/value\s*=\s*/     end=/\s/ end=/$/
+
 "Catch errors caused by too many right parentheses
 syn region imcnpParen transparent start="(" end=")" contains=ALLBUT,imcnpParenError,@imcnpCommentGroup,cIncluded,@spell
 syn match  imcnpParenError   ")"


### PR DESCRIPTION
The [MCNP 6.3.1 Manual § 5.13.6](https://mcnp.lanl.gov/pdf_files/TechReport_2024_LANL_LA-UR-24-24602Rev.1_KuleszaAdamsEtAl.pdf#subsection.5.13.6) describes the `PTRAC` card and its keywords.

This PR adds syntax highlighting for `ptrac` and different coloring for its output control, event filter, and history filter keywords.

